### PR TITLE
Add KafkaConfig

### DIFF
--- a/crd/servicedomainclusters.mercury.redhat.io-v1.yml
+++ b/crd/servicedomainclusters.mercury.redhat.io-v1.yml
@@ -18,6 +18,19 @@ spec:
       openAPIV3Schema:
         properties:
           spec:
+            properties:
+              kafka:
+                properties:
+                  replicas:
+                    type: integer
+                  storage:
+                    properties:
+                      size:
+                        type: string
+                      type:
+                        type: string
+                    type: object
+                type: object
             type: object
           status:
             properties:

--- a/mercury-api/src/main/java/com/redhat/mercury/operator/model/KafkaConfig.java
+++ b/mercury-api/src/main/java/com/redhat/mercury/operator/model/KafkaConfig.java
@@ -1,8 +1,5 @@
 package com.redhat.mercury.operator.model;
 
-import java.io.Serializable;
-import java.util.List;
-
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 
@@ -22,20 +19,9 @@ import lombok.experimental.Accessors;
 @Setter
 @Accessors(chain = true)
 @Buildable(editableEnabled = false, lazyCollectionInitEnabled = false, builderPackage = "io.fabric8.kubernetes.api.builder")
-public class ServiceDomainSpec implements Serializable {
-    public enum Type {
-        CustomerOffer(),
-        CustomerCreditRating(),
-        PartyRoutingProfile()
-    }
+public class KafkaConfig {
 
-    public enum ExposeType {
-        http
-    }
+    private Integer replicas = 1;
+    private KafkaStorage storage = new KafkaStorage();
 
-    private String businessImage;
-    private String serviceDomainCluster;
-    private Type type;
-    private List<ExposeType> expose;
-    private List<Binding> binding;
 }

--- a/mercury-api/src/main/java/com/redhat/mercury/operator/model/KafkaStorage.java
+++ b/mercury-api/src/main/java/com/redhat/mercury/operator/model/KafkaStorage.java
@@ -1,8 +1,5 @@
 package com.redhat.mercury.operator.model;
 
-import java.io.Serializable;
-import java.util.List;
-
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 
@@ -22,20 +19,9 @@ import lombok.experimental.Accessors;
 @Setter
 @Accessors(chain = true)
 @Buildable(editableEnabled = false, lazyCollectionInitEnabled = false, builderPackage = "io.fabric8.kubernetes.api.builder")
-public class ServiceDomainSpec implements Serializable {
-    public enum Type {
-        CustomerOffer(),
-        CustomerCreditRating(),
-        PartyRoutingProfile()
-    }
+public class KafkaStorage {
 
-    public enum ExposeType {
-        http
-    }
+    private String type = "ephemeral";
+    private String size;
 
-    private String businessImage;
-    private String serviceDomainCluster;
-    private Type type;
-    private List<ExposeType> expose;
-    private List<Binding> binding;
 }

--- a/mercury-api/src/main/java/com/redhat/mercury/operator/model/ServiceDomainCluster.java
+++ b/mercury-api/src/main/java/com/redhat/mercury/operator/model/ServiceDomainCluster.java
@@ -10,4 +10,10 @@ import io.fabric8.kubernetes.model.annotation.Version;
 @Version("v1alpha1")
 @ShortNames("sdc")
 public class ServiceDomainCluster extends CustomResource<ServiceDomainClusterSpec, ServiceDomainClusterStatus> implements Namespaced {
+
+    public ServiceDomainCluster() {
+        super();
+        this.setSpec(new ServiceDomainClusterSpec());
+    }
+
 }

--- a/mercury-api/src/main/java/com/redhat/mercury/operator/model/ServiceDomainClusterSpec.java
+++ b/mercury-api/src/main/java/com/redhat/mercury/operator/model/ServiceDomainClusterSpec.java
@@ -18,4 +18,7 @@ import lombok.experimental.Accessors;
 @Accessors(chain = true)
 @Buildable(editableEnabled = false, lazyCollectionInitEnabled = false, builderPackage = "io.fabric8.kubernetes.api.builder")
 public class ServiceDomainClusterSpec {
+
+    private KafkaConfig kafka = new KafkaConfig();
+
 }

--- a/mercury-operator/examples/crs/my-customer-offer.yaml
+++ b/mercury-operator/examples/crs/my-customer-offer.yaml
@@ -1,0 +1,12 @@
+apiVersion: mercury.redhat.io/v1alpha1
+kind: ServiceDomain
+metadata:
+  name: customer-offer
+  labels:
+    app: example
+spec:
+  businessImage: quay.io/ecosystem-appeng/customer-offer-example:1.0.1-SNAPSHOT
+  serviceDomainCluster: my-first-sdc
+  type: CustomerOffer
+  expose:
+    - http

--- a/mercury-operator/examples/crs/my-first-sdc.yaml
+++ b/mercury-operator/examples/crs/my-first-sdc.yaml
@@ -1,0 +1,11 @@
+apiVersion: mercury.redhat.io/v1alpha1
+kind: ServiceDomainCluster
+metadata:
+  name: my-first-sdc
+  labels:
+    app: examples
+spec:
+  kafka:
+    replicas: 1
+    storage:
+      type: ephemeral

--- a/mercury-operator/install/mercury-operator.yml
+++ b/mercury-operator/install/mercury-operator.yml
@@ -7,64 +7,6 @@ metadata:
   name: mercury-operator
   namespace: mercury
 ---
-apiVersion: v1
-kind: Service
-metadata:
-  labels:
-    app.kubernetes.io/name: mercury-operator
-  name: mercury-operator
-  namespace: mercury
-spec:
-  ports:
-    - name: http
-      port: 80
-      targetPort: 8080
-  selector:
-    app.kubernetes.io/name: mercury-operator
-  type: ClusterIP
----
-apiVersion: rbac.authorization.k8s.io/v1
-kind: RoleBinding
-metadata:
-  name: mercury-operator-view
-  namespace: mercury
-roleRef:
-  kind: ClusterRole
-  apiGroup: rbac.authorization.k8s.io
-  name: view
-subjects:
-  - kind: ServiceAccount
-    name: mercury-operator
-    namespace: mercury
----
-apiVersion: rbac.authorization.k8s.io/v1
-kind: RoleBinding
-metadata:
-  name: servicedomainclustercontroller-crd-validating-role-binding
-  namespace: mercury
-roleRef:
-  kind: ClusterRole
-  apiGroup: rbac.authorization.k8s.io
-  name: josdk-crd-validating-cluster-role
-subjects:
-  - kind: ServiceAccount
-    name: mercury-operator
-    namespace: mercury
----
-apiVersion: rbac.authorization.k8s.io/v1
-kind: RoleBinding
-metadata:
-  name: servicedomaincontroller-crd-validating-role-binding
-  namespace: mercury
-roleRef:
-  kind: ClusterRole
-  apiGroup: rbac.authorization.k8s.io
-  name: josdk-crd-validating-cluster-role
-subjects:
-  - kind: ServiceAccount
-    name: mercury-operator
-    namespace: mercury
----
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
@@ -73,27 +15,22 @@ metadata:
 rules:
   - apiGroups:
       - ""
-      - mercury.redhat.io
-      - apiextensions.k8s.io
-      - rbac.authorization.k8s.io
-      - kafka.strimzi.io
       - apps
       - extensions
+      - mercury.redhat.io
+      - kafka.strimzi.io
       - camel.apache.org
     resources:
       - servicedomainclusters
       - servicedomainclusters/status
       - servicedomains
       - servicedomains/status
-      - customresourcedefinitions
-      - roles
-      - rolebindings
       - kafkas
       - kafkatopics
-      - serviceaccounts
+      - kafkausers
+      - integrations
       - services
       - deployments
-      - integrations
     verbs:
       - "*"
 ---
@@ -111,6 +48,33 @@ subjects:
     name: mercury-operator
     namespace: mercury
 ---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: mercury-operator-role
+  namespace: mercury
+rules:
+  - apiGroups:
+      - ""
+    resources:
+      - configmaps
+    verbs:
+      - get
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: mercury-operator-role-binding
+  namespace: mercury
+roleRef:
+  kind: Role
+  apiGroup: rbac.authorization.k8s.io
+  name: mercury-operator-role
+subjects:
+  - kind: ServiceAccount
+    name: mercury-operator
+    namespace: mercury
+---
 apiVersion: apps/v1
 kind: Deployment
 metadata:
@@ -119,7 +83,6 @@ metadata:
   name: mercury-operator
   namespace: mercury
 spec:
-  replicas: 1
   selector:
     matchLabels:
       app.kubernetes.io/name: mercury-operator
@@ -143,10 +106,6 @@ spec:
               path: /q/health/live
               port: 8080
               scheme: HTTP
-            initialDelaySeconds: 0
-            periodSeconds: 30
-            successThreshold: 1
-            timeoutSeconds: 10
           name: mercury-operator
           ports:
             - containerPort: 8080
@@ -158,8 +117,4 @@ spec:
               path: /q/health/ready
               port: 8080
               scheme: HTTP
-            initialDelaySeconds: 0
-            periodSeconds: 30
-            successThreshold: 1
-            timeoutSeconds: 10
       serviceAccount: mercury-operator

--- a/mercury-operator/src/main/java/com/redhat/mercury/operator/event/KafkaServiceEvent.java
+++ b/mercury-operator/src/main/java/com/redhat/mercury/operator/event/KafkaServiceEvent.java
@@ -1,4 +1,4 @@
-package com.redhat.mercury.operator;
+package com.redhat.mercury.operator.event;
 
 import io.fabric8.kubernetes.client.Watcher;
 import io.javaoperatorsdk.operator.processing.event.DefaultEvent;

--- a/mercury-operator/src/main/java/com/redhat/mercury/operator/event/KafkaServiceEventSource.java
+++ b/mercury-operator/src/main/java/com/redhat/mercury/operator/event/KafkaServiceEventSource.java
@@ -1,4 +1,4 @@
-package com.redhat.mercury.operator;
+package com.redhat.mercury.operator.event;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;

--- a/mercury-operator/src/main/java/com/redhat/mercury/operator/reflection/DependenciesConfiguration.java
+++ b/mercury-operator/src/main/java/com/redhat/mercury/operator/reflection/DependenciesConfiguration.java
@@ -1,0 +1,48 @@
+package com.redhat.mercury.operator.reflection;
+
+import io.quarkus.runtime.annotations.RegisterForReflection;
+import io.strimzi.api.kafka.model.Kafka;
+import io.strimzi.api.kafka.model.KafkaClusterSpec;
+import io.strimzi.api.kafka.model.KafkaSpec;
+import io.strimzi.api.kafka.model.KafkaTopic;
+import io.strimzi.api.kafka.model.KafkaTopicSpec;
+import io.strimzi.api.kafka.model.KafkaUser;
+import io.strimzi.api.kafka.model.KafkaUserSpec;
+import io.strimzi.api.kafka.model.ZookeeperClusterSpec;
+import io.strimzi.api.kafka.model.listener.arraylistener.GenericKafkaListener;
+import io.strimzi.api.kafka.model.listener.arraylistener.KafkaListenerType;
+import io.strimzi.api.kafka.model.status.Condition;
+import io.strimzi.api.kafka.model.status.KafkaStatus;
+import io.strimzi.api.kafka.model.status.KafkaTopicStatus;
+import io.strimzi.api.kafka.model.status.KafkaUserStatus;
+import io.strimzi.api.kafka.model.status.ListenerAddress;
+import io.strimzi.api.kafka.model.status.ListenerStatus;
+import io.strimzi.api.kafka.model.status.Status;
+import io.strimzi.api.kafka.model.storage.EphemeralStorage;
+import io.strimzi.api.kafka.model.storage.PersistentClaimStorage;
+import io.strimzi.api.kafka.model.storage.Storage;
+
+@RegisterForReflection(targets = {
+        Kafka.class,
+        KafkaSpec.class,
+        KafkaStatus.class,
+        KafkaTopic.class,
+        KafkaTopicSpec.class,
+        KafkaTopicStatus.class,
+        KafkaUser.class,
+        KafkaUserSpec.class,
+        KafkaUserStatus.class,
+        KafkaClusterSpec.class,
+        ZookeeperClusterSpec.class,
+        Storage.class,
+        GenericKafkaListener.class,
+        KafkaListenerType.class,
+        EphemeralStorage.class,
+        PersistentClaimStorage.class,
+        Status.class,
+        Condition.class,
+        ListenerStatus.class,
+        ListenerAddress.class
+})
+public class DependenciesConfiguration {
+}

--- a/mercury-operator/src/main/resources/application.properties
+++ b/mercury-operator/src/main/resources/application.properties
@@ -1,2 +1,3 @@
 quarkus.operator-sdk.crd.output-directory=../../crd
 application.version=${project.version}
+quarkus.operator-sdk.crd.validate=false

--- a/mercury-operator/src/test/java/com/redhat/mercury/operator/controller/AbstractControllerTest.java
+++ b/mercury-operator/src/test/java/com/redhat/mercury/operator/controller/AbstractControllerTest.java
@@ -1,5 +1,7 @@
 package com.redhat.mercury.operator.controller;
 
+import java.util.List;
+
 import javax.inject.Inject;
 
 import com.redhat.mercury.operator.model.ServiceDomain;
@@ -17,8 +19,6 @@ import io.strimzi.api.kafka.model.status.KafkaStatusBuilder;
 import io.strimzi.api.kafka.model.status.ListenerAddressBuilder;
 import io.strimzi.api.kafka.model.status.ListenerStatusBuilder;
 
-import java.util.List;
-
 import static com.redhat.mercury.operator.controller.ServiceDomainClusterController.KAFKA_LISTENER_TYPE_PLAIN;
 
 public abstract class AbstractControllerTest {
@@ -33,8 +33,8 @@ public abstract class AbstractControllerTest {
     @Inject
     protected ServiceDomainClusterController serviceDomainClusterController;
 
-    public Kafka getExpectedKafKa(String sdcUid, String sdcName, String sdcNamespace){
-        final Kafka kafka = serviceDomainClusterController.createKafkaObj(sdcUid, sdcName, sdcNamespace);
+    public Kafka getExpectedKafKa(ServiceDomainCluster sdc) {
+        final Kafka kafka = serviceDomainClusterController.createKafkaObj(sdc);
 
         final KafkaStatus status = new KafkaStatusBuilder().withListeners(new ListenerStatusBuilder()
                         .withType(KAFKA_LISTENER_TYPE_PLAIN)
@@ -71,7 +71,7 @@ public abstract class AbstractControllerTest {
         final ServiceDomain sd = new ServiceDomain();
         sd.setMetadata(new ObjectMetaBuilder().withName(sdName).withNamespace(SERVICE_DOMAIN_CLUSTER_NAMESPACE).build());
 
-        if(withHttpExpose) {
+        if (withHttpExpose) {
             sd.setSpec(new ServiceDomainSpecBuilder()
                     .withBusinessImage("testImage")
                     .withServiceDomainCluster(SERVICE_DOMAIN_CLUSTER_NAME)
@@ -85,13 +85,14 @@ public abstract class AbstractControllerTest {
                     .withType(ServiceDomainSpec.Type.CustomerOffer)
                     .build());
         }
-
         return sd;
     }
 
     protected boolean isServiceDomainClusterStatusUpdatedWithKafkaBrokerUrl(String sdcName) {
-        return mockServer.getClient().resources(ServiceDomainCluster.class).inNamespace(SERVICE_DOMAIN_CLUSTER_NAMESPACE).withName(sdcName).get() != null
-                && mockServer.getClient().resources(ServiceDomainCluster.class).inNamespace(SERVICE_DOMAIN_CLUSTER_NAMESPACE).withName(sdcName).get().getStatus() != null
-                && mockServer.getClient().resources(ServiceDomainCluster.class).inNamespace(SERVICE_DOMAIN_CLUSTER_NAMESPACE).withName(sdcName).get().getStatus().getKafkaBroker() != null;
+        ServiceDomainCluster sdc = mockServer.getClient().resources(ServiceDomainCluster.class)
+                .inNamespace(SERVICE_DOMAIN_CLUSTER_NAMESPACE)
+                .withName(sdcName)
+                .get();
+        return sdc != null && sdc.getStatus() != null && sdc.getStatus().getKafkaBroker() != null;
     }
 }

--- a/mercury-operator/src/test/java/com/redhat/mercury/operator/controller/ServiceDomainClusterControllerTest.java
+++ b/mercury-operator/src/test/java/com/redhat/mercury/operator/controller/ServiceDomainClusterControllerTest.java
@@ -1,87 +1,113 @@
 package com.redhat.mercury.operator.controller;
 
+import java.time.Duration;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.TimeoutException;
+
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
 import com.redhat.mercury.operator.model.ServiceDomainCluster;
 
-import io.fabric8.kubernetes.api.model.KubernetesResourceList;
 import io.fabric8.kubernetes.api.model.Namespace;
 import io.fabric8.kubernetes.api.model.NamespaceBuilder;
-import io.fabric8.kubernetes.api.model.OwnerReference;
-import io.fabric8.kubernetes.api.model.rbac.Role;
-import io.fabric8.kubernetes.api.model.rbac.RoleBinding;
+import io.fabric8.kubernetes.api.model.ObjectMetaBuilder;
 import io.fabric8.kubernetes.client.NamespacedKubernetesClient;
 import io.quarkus.test.junit.QuarkusTest;
 import io.quarkus.test.kubernetes.client.WithKubernetesTestServer;
+import io.smallrye.mutiny.Multi;
 import io.strimzi.api.kafka.model.Kafka;
 
-import java.util.List;
-
-import static com.redhat.mercury.operator.controller.ServiceDomainClusterController.ROLE_BINDING;
-import static com.redhat.mercury.operator.controller.ServiceDomainClusterController.ROLE_REF;
-import static com.redhat.mercury.operator.controller.ServiceDomainClusterController.ROLE_REF_API_GROUP;
-import static com.redhat.mercury.operator.controller.ServiceDomainClusterController.ROLE_REF_KIND;
-import static com.redhat.mercury.operator.controller.ServiceDomainClusterController.SERVICE_DOMAIN_ROLE;
-import static com.redhat.mercury.operator.controller.ServiceDomainClusterController.SUBJECT_KIND;
-import static com.redhat.mercury.operator.controller.ServiceDomainClusterController.SUBJECT_NAME;
 import static java.util.concurrent.TimeUnit.MINUTES;
 import static java.util.concurrent.TimeUnit.SECONDS;
 import static org.awaitility.Awaitility.await;
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.fail;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 @QuarkusTest
 @WithKubernetesTestServer
-public class ServiceDomainClusterControllerTest extends AbstractControllerTest{
+public class ServiceDomainClusterControllerTest extends AbstractControllerTest {
 
     @BeforeEach
-    public void beforeEach(){
+    public void beforeEach() {
         final NamespacedKubernetesClient client = mockServer.getClient();
 
         final Namespace namespace = client.namespaces().withName(SERVICE_DOMAIN_CLUSTER_NAMESPACE).get();
-        if(namespace == null) {
+        if (namespace == null) {
             client.namespaces().create(new NamespaceBuilder().withNewMetadata().withName(SERVICE_DOMAIN_CLUSTER_NAMESPACE).endMetadata().build());
         }
     }
 
     @AfterEach
-    public void afterEach(){
+    public void afterEach() {
         final NamespacedKubernetesClient client = mockServer.getClient();
 
-        final KubernetesResourceList<ServiceDomainCluster> sdcList = client.resources(ServiceDomainCluster.class).inNamespace(SERVICE_DOMAIN_CLUSTER_NAMESPACE).list();
-        if(sdcList != null && sdcList.getItems() != null && !sdcList.getItems().isEmpty()){
-            sdcList.getItems().forEach(sdc -> client.resources(ServiceDomainCluster.class).inNamespace(SERVICE_DOMAIN_CLUSTER_NAMESPACE).delete(sdc));
-        }
+        client.resources(ServiceDomainCluster.class).list()
+                .getItems().forEach(sdc -> client.resources(ServiceDomainCluster.class)
+                        .inNamespace(sdc.getMetadata().getNamespace())
+                        .withName(sdc.getMetadata().getName())
+                        .delete());
 
-        final Kafka kafka = client.resources(Kafka.class).inNamespace(SERVICE_DOMAIN_CLUSTER_NAMESPACE).withName(SERVICE_DOMAIN_CLUSTER_NAME).get();
-        if(kafka != null){
-            client.resources(Kafka.class).inNamespace(SERVICE_DOMAIN_CLUSTER_NAMESPACE).delete(kafka);
-        }
-
-        final Role role = client.resources(Role.class).withName(SERVICE_DOMAIN_ROLE).get();
-        if(role != null){
-            client.resources(Role.class).delete(role);
-        }
-
-        final RoleBinding roleBinding = client.resources(RoleBinding.class).withName(ROLE_BINDING).get();
-        if(roleBinding != null){
-            client.resources(RoleBinding.class).delete(roleBinding);
+        final Kafka kafka = client.resources(Kafka.class).inNamespace(SERVICE_DOMAIN_CLUSTER_NAMESPACE)
+                .withName(SERVICE_DOMAIN_CLUSTER_NAME)
+                .get();
+        if (kafka != null) {
+            client.resources(Kafka.class)
+                    .inNamespace(kafka.getMetadata().getNamespace())
+                    .withName(kafka.getMetadata().getName())
+                    .delete();
         }
     }
 
     @Test
-    public void addServiceDomainClusterTest(){
+    void createDefaultServiceDomainCluster() throws ExecutionException, InterruptedException, TimeoutException {
+        ServiceDomainCluster sdc = new ServiceDomainCluster();
+        sdc.setMetadata(new ObjectMetaBuilder().withName("my-sdc").build());
+
+        ServiceDomainCluster serviceDomainCluster = mockServer.getClient().resources(ServiceDomainCluster.class)
+                .inNamespace("test-ns")
+                .create(sdc);
+
+        CompletableFuture<Kafka> result = CompletableFuture.supplyAsync(() -> {
+            Kafka kafka = null;
+            while (kafka == null) {
+                kafka = mockServer.getClient()
+                        .resources(Kafka.class)
+                        .inNamespace(serviceDomainCluster.getMetadata().getNamespace())
+                        .withName(serviceDomainCluster.getMetadata().getName())
+                        .get();
+                try {
+                    Thread.sleep(500);
+                } catch (InterruptedException e) {
+                    fail("Interrupted thread");
+                }
+            }
+            return kafka;
+        });
+        Multi.createFrom()
+                .ticks()
+                .every(Duration.ofMillis(500)).onItem().transform(e -> mockServer.getClient()
+                        .resources(Kafka.class)
+                        .inNamespace(serviceDomainCluster.getMetadata().getNamespace())
+                        .withName(serviceDomainCluster.getMetadata().getName())
+                        .get()).filter(k -> k != null).collect().first();
+        Kafka kafka = result.get(1, MINUTES);
+        assertEquals("my-sdc", kafka.getMetadata().getName());
+    }
+
+    @Test
+    public void addServiceDomainClusterTest() {
         ServiceDomainCluster cluster = createServiceDomainCluster();
         final String sdcNamespace = cluster.getMetadata().getNamespace();
 
         final NamespacedKubernetesClient client = mockServer.getClient();
 
-        Kafka expectedKafka = getExpectedKafKa("", SERVICE_DOMAIN_CLUSTER_NAME, sdcNamespace);
+        Kafka expectedKafka = getExpectedKafKa(cluster);
         client.resources(Kafka.class).inNamespace(sdcNamespace).create(expectedKafka);
         await().atMost(2, MINUTES).until(() -> client.resources(Kafka.class).inNamespace(sdcNamespace).withName(SERVICE_DOMAIN_CLUSTER_NAME).get() != null);
         Kafka fetchedKafka = client.resources(Kafka.class).inNamespace(sdcNamespace).withName(SERVICE_DOMAIN_CLUSTER_NAME).get();
@@ -89,91 +115,52 @@ public class ServiceDomainClusterControllerTest extends AbstractControllerTest{
 
         cluster = client.resources(ServiceDomainCluster.class).inNamespace(sdcNamespace).create(cluster);
 
-        expectedKafka = getExpectedKafKa(cluster.getMetadata().getUid(), SERVICE_DOMAIN_CLUSTER_NAME, sdcNamespace);
+        expectedKafka = getExpectedKafKa(cluster);
         client.resources(Kafka.class).inNamespace(sdcNamespace).replace(expectedKafka);
-        await().atMost(2, MINUTES).until(() -> client.resources(Kafka.class).inNamespace(sdcNamespace).withName(SERVICE_DOMAIN_CLUSTER_NAME).get() != null);
-
-        await().atMost(2, MINUTES).until(() -> client.rbac().roles().withName(SERVICE_DOMAIN_ROLE).get() != null);
-        final Role role = client.rbac().roles().withName(SERVICE_DOMAIN_ROLE).get();
-        assertEquals(SERVICE_DOMAIN_ROLE, role.getMetadata().getName());
-
-        List<OwnerReference> ownerReferences = role.getMetadata().getOwnerReferences();
-        assertNotNull(ownerReferences);
-        assertFalse(ownerReferences.isEmpty());
-
-        OwnerReference ownerReference = ownerReferences.get(0);
-        assertNotNull(ownerReference);
-        assertEquals(cluster.getMetadata().getName(), ownerReference.getName());
-        assertEquals(ServiceDomainClusterController.SERVICE_DOMAIN_CLUSTER_OWNER_REFERENCES_KIND, ownerReference.getKind());
-        assertEquals(ServiceDomainClusterController.SERVICE_DOMAIN_CLUSTER_OWNER_REFERENCES_API_VERSION, ownerReference.getApiVersion());
-
-        await().atMost(2, MINUTES).until(() -> client.rbac().roleBindings().withName(ROLE_BINDING).get() != null);
-        final RoleBinding roleBinding = client.rbac().roleBindings().withName(ROLE_BINDING).get();
-        assertNotNull(roleBinding);
-        assertEquals(ROLE_BINDING, roleBinding.getMetadata().getName());
-
-        ownerReferences = roleBinding.getMetadata().getOwnerReferences();
-        assertNotNull(ownerReferences);
-        assertFalse(ownerReferences.isEmpty());
-
-        ownerReference = ownerReferences.get(0);
-        assertNotNull(ownerReference);
-        assertEquals(cluster.getMetadata().getName(), ownerReference.getName());
-        assertEquals(ServiceDomainClusterController.SERVICE_DOMAIN_CLUSTER_OWNER_REFERENCES_KIND, ownerReference.getKind());
-        assertEquals(ServiceDomainClusterController.SERVICE_DOMAIN_CLUSTER_OWNER_REFERENCES_API_VERSION, ownerReference.getApiVersion());
-        assertEquals(ROLE_REF, roleBinding.getRoleRef().getName());
-        assertEquals(ROLE_REF_API_GROUP, roleBinding.getRoleRef().getApiGroup());
-        assertEquals(ROLE_REF_KIND, roleBinding.getRoleRef().getKind());
-        assertEquals(SUBJECT_NAME, roleBinding.getSubjects().get(0).getName());
-        assertEquals(SUBJECT_KIND, roleBinding.getSubjects().get(0).getKind());
+        await().atMost(2, MINUTES).until(() -> client.resources(Kafka.class)
+                .inNamespace(sdcNamespace)
+                .withName(SERVICE_DOMAIN_CLUSTER_NAME)
+                .get() != null);
 
         await().atMost(20, SECONDS).until(() -> isServiceDomainClusterStatusUpdatedWithKafkaBrokerUrl(SERVICE_DOMAIN_CLUSTER_NAME));
-        final String kafkaBrokerUrl = client.resources(ServiceDomainCluster.class).inNamespace(sdcNamespace).withName(SERVICE_DOMAIN_CLUSTER_NAME).get().getStatus().getKafkaBroker();
+        final String kafkaBrokerUrl = client.resources(ServiceDomainCluster.class)
+                .inNamespace(sdcNamespace)
+                .withName(SERVICE_DOMAIN_CLUSTER_NAME)
+                .get()
+                .getStatus()
+                .getKafkaBroker();
         assertNotNull(kafkaBrokerUrl);
     }
 
     @Test
-    public void addMultipleServiceDomainClusterTest(){
-        ServiceDomainCluster cluster = createServiceDomainCluster();
-        final String sdcNamespace = cluster.getMetadata().getNamespace();
+    public void addMultipleServiceDomainClusterTest() {
+        for (int i = 0; i < 3; i++) {
+            final ServiceDomainCluster cluster = createServiceDomainCluster(SERVICE_DOMAIN_CLUSTER_NAME + i);
+            final NamespacedKubernetesClient client = mockServer.getClient();
+            client.resources(ServiceDomainCluster.class)
+                    .inNamespace(cluster.getMetadata().getNamespace())
+                    .create(cluster);
 
-        final NamespacedKubernetesClient client = mockServer.getClient();
+            ServiceDomainCluster current = client.resources(ServiceDomainCluster.class)
+                    .inNamespace(cluster.getMetadata().getNamespace())
+                    .withName(cluster.getMetadata().getName())
+                    .get();
 
-        client.resources(ServiceDomainCluster.class).inNamespace(sdcNamespace).create(cluster);
+            assertNotNull(current);
+            assertTrue(client.resources(ServiceDomainCluster.class)
+                    .inNamespace(cluster.getMetadata().getNamespace())
+                    .withName(cluster.getMetadata().getName())
+                    .delete());
 
-        await().atMost(2, MINUTES).until(() -> client.rbac().roles().withName(SERVICE_DOMAIN_ROLE).get() != null);
-        Role role = client.rbac().roles().withName(SERVICE_DOMAIN_ROLE).get();
-        assertNotNull(role);
+            await().atMost(2, MINUTES).until(() -> client.resources(ServiceDomainCluster.class)
+                    .inNamespace(cluster.getMetadata().getNamespace())
+                    .withName(cluster.getMetadata().getName())
+                    .get() == null);
 
-        await().atMost(2, MINUTES).until(() -> client.rbac().roleBindings().withName(ROLE_BINDING).get() != null);
-        RoleBinding roleBinding = client.rbac().roleBindings().withName(ROLE_BINDING).get();
-        assertNotNull(roleBinding);
-
-        cluster = client.resources(ServiceDomainCluster.class).withName(SERVICE_DOMAIN_CLUSTER_NAME).get();
-        Boolean deleted = client.resources(ServiceDomainCluster.class).delete(cluster);
-        assertTrue(deleted);
-
-        await().atMost(2, MINUTES).until(() -> client.resources(ServiceDomainCluster.class).withName(SERVICE_DOMAIN_CLUSTER_NAME).get() == null);
-        cluster = client.resources(ServiceDomainCluster.class).withName(SERVICE_DOMAIN_CLUSTER_NAME).get();
-        assertNull(cluster);
-
-        cluster = createServiceDomainCluster(SERVICE_DOMAIN_CLUSTER_NAME + 2);
-        client.resources(ServiceDomainCluster.class).inNamespace(sdcNamespace).create(cluster);
-
-        await().atMost(2, MINUTES).until(() -> client.rbac().roles().withName(SERVICE_DOMAIN_ROLE).get() != null);
-        role = client.rbac().roles().withName(SERVICE_DOMAIN_ROLE).get();
-        assertNotNull(role);
-
-        await().atMost(2, MINUTES).until(() -> client.rbac().roleBindings().withName(ROLE_BINDING).get() != null);
-        roleBinding = client.rbac().roleBindings().withName(ROLE_BINDING).get();
-        assertNotNull(roleBinding);
-
-        cluster = client.resources(ServiceDomainCluster.class).withName(SERVICE_DOMAIN_CLUSTER_NAME+ 2).get();
-        deleted = client.resources(ServiceDomainCluster.class).delete(cluster);
-        assertTrue(deleted);
-
-        await().atMost(2, MINUTES).until(() -> client.resources(ServiceDomainCluster.class).withName(SERVICE_DOMAIN_CLUSTER_NAME+ 2).get() == null);
-        cluster = client.resources(ServiceDomainCluster.class).withName(SERVICE_DOMAIN_CLUSTER_NAME+ 2).get();
-        assertNull(cluster);
+            assertNull(client.resources(ServiceDomainCluster.class)
+                    .inNamespace(cluster.getMetadata().getNamespace())
+                    .withName(cluster.getMetadata().getName())
+                    .get());
+        }
     }
 }

--- a/mercury-operator/src/test/java/com/redhat/mercury/operator/controller/ServiceDomainControllerTest.java
+++ b/mercury-operator/src/test/java/com/redhat/mercury/operator/controller/ServiceDomainControllerTest.java
@@ -1,23 +1,26 @@
 package com.redhat.mercury.operator.controller;
 
+import java.io.IOException;
+import java.io.InputStream;
+import java.util.List;
+
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
 import com.redhat.mercury.operator.model.ServiceDomain;
 import com.redhat.mercury.operator.model.ServiceDomainCluster;
+import com.redhat.mercury.operator.model.ServiceDomainClusterSpecBuilder;
 
 import io.fabric8.kubernetes.api.model.ConfigMap;
 import io.fabric8.kubernetes.api.model.GenericKubernetesResource;
 import io.fabric8.kubernetes.api.model.KubernetesResourceList;
 import io.fabric8.kubernetes.api.model.Namespace;
 import io.fabric8.kubernetes.api.model.NamespaceBuilder;
+import io.fabric8.kubernetes.api.model.ObjectMetaBuilder;
 import io.fabric8.kubernetes.api.model.OwnerReference;
 import io.fabric8.kubernetes.api.model.Service;
-import io.fabric8.kubernetes.api.model.ServiceAccount;
 import io.fabric8.kubernetes.api.model.apps.Deployment;
-import io.fabric8.kubernetes.api.model.rbac.Role;
-import io.fabric8.kubernetes.api.model.rbac.RoleBinding;
 import io.fabric8.kubernetes.client.NamespacedKubernetesClient;
 import io.fabric8.kubernetes.client.dsl.base.ResourceDefinitionContext;
 import io.quarkus.test.junit.QuarkusTest;
@@ -25,13 +28,6 @@ import io.quarkus.test.kubernetes.client.WithKubernetesTestServer;
 import io.strimzi.api.kafka.model.Kafka;
 import io.strimzi.api.kafka.model.KafkaTopic;
 
-import java.io.IOException;
-import java.io.InputStream;
-import java.util.List;
-
-import static com.redhat.mercury.operator.controller.ServiceDomainClusterController.ROLE_BINDING;
-import static com.redhat.mercury.operator.controller.ServiceDomainClusterController.SERVICE_DOMAIN_ROLE;
-import static com.redhat.mercury.operator.controller.ServiceDomainController.BINDING_SERVICE_SA;
 import static com.redhat.mercury.operator.controller.ServiceDomainController.INTEGRATION_SUFFIX;
 import static java.util.concurrent.TimeUnit.MINUTES;
 import static java.util.concurrent.TimeUnit.SECONDS;
@@ -43,20 +39,20 @@ import static org.junit.jupiter.api.Assertions.assertNull;
 
 @QuarkusTest
 @WithKubernetesTestServer
-public class ServiceDomainControllerTest extends AbstractControllerTest{
+public class ServiceDomainControllerTest extends AbstractControllerTest {
 
     @BeforeEach
     public void beforeEach() throws IOException {
         final NamespacedKubernetesClient client = mockServer.getClient();
 
         final Namespace namespace = client.namespaces().withName(SERVICE_DOMAIN_CLUSTER_NAMESPACE).get();
-        if(namespace == null) {
+        if (namespace == null) {
             client.namespaces().create(new NamespaceBuilder().withNewMetadata().withName(SERVICE_DOMAIN_CLUSTER_NAMESPACE).endMetadata().build());
         }
 
         final String sdConfigMapName = "integration-" + SERVICE_DOMAIN_NAME + "-http";
         ConfigMap configMap = client.configMaps().inNamespace(client.getNamespace()).withName(sdConfigMapName).get();
-        if(configMap == null) {
+        if (configMap == null) {
             try (final InputStream inputStream = this.getClass().getClassLoader().getResourceAsStream("sdConfigMap.yaml")) {
                 if (inputStream != null) {
                     client.configMaps().inNamespace(client.getNamespace()).load(inputStream).create();
@@ -68,17 +64,20 @@ public class ServiceDomainControllerTest extends AbstractControllerTest{
         }
 
         //Hack so that the cluster will already have a kafka broker
-        Kafka expectedKafka = getExpectedKafKa("", SERVICE_DOMAIN_CLUSTER_NAME, SERVICE_DOMAIN_CLUSTER_NAMESPACE);
-        Kafka fetchedKafka = client.resources(Kafka.class).inNamespace(SERVICE_DOMAIN_CLUSTER_NAMESPACE).withName(SERVICE_DOMAIN_CLUSTER_NAME).get();
-        if(fetchedKafka == null) {
-            client.resources(Kafka.class).inNamespace(SERVICE_DOMAIN_CLUSTER_NAMESPACE).create(expectedKafka);
-            await().atMost(2, MINUTES).until(() -> client.resources(Kafka.class).inNamespace(SERVICE_DOMAIN_CLUSTER_NAMESPACE).withName(SERVICE_DOMAIN_CLUSTER_NAME).get() != null);
-            fetchedKafka = client.resources(Kafka.class).inNamespace(SERVICE_DOMAIN_CLUSTER_NAMESPACE).withName(SERVICE_DOMAIN_CLUSTER_NAME).get();
+        ServiceDomainCluster sdc = new ServiceDomainCluster();
+        sdc.setMetadata(new ObjectMetaBuilder().withNamespace(SERVICE_DOMAIN_CLUSTER_NAMESPACE).withName(SERVICE_DOMAIN_CLUSTER_NAME).build());
+        sdc.setSpec(new ServiceDomainClusterSpecBuilder().build());
+        Kafka expectedKafka = getExpectedKafKa(sdc);
+        Kafka fetchedKafka = client.resources(Kafka.class).inNamespace(sdc.getMetadata().getNamespace()).withName(SERVICE_DOMAIN_CLUSTER_NAME).get();
+        if (fetchedKafka == null) {
+            client.resources(Kafka.class).inNamespace(sdc.getMetadata().getNamespace()).create(expectedKafka);
+            await().atMost(2, MINUTES).until(() -> client.resources(Kafka.class).inNamespace(sdc.getMetadata().getNamespace()).withName(SERVICE_DOMAIN_CLUSTER_NAME).get() != null);
+            fetchedKafka = client.resources(Kafka.class).inNamespace(sdc.getMetadata().getNamespace()).withName(SERVICE_DOMAIN_CLUSTER_NAME).get();
             assertNotNull(fetchedKafka);
         }
 
         ServiceDomainCluster fetchedCluster = client.resources(ServiceDomainCluster.class).inNamespace(SERVICE_DOMAIN_CLUSTER_NAMESPACE).withName(SERVICE_DOMAIN_CLUSTER_NAME).get();
-        if(fetchedCluster == null) {
+        if (fetchedCluster == null) {
             ServiceDomainCluster desiredCluster = createServiceDomainCluster();
             fetchedCluster = client.resources(ServiceDomainCluster.class).inNamespace(SERVICE_DOMAIN_CLUSTER_NAMESPACE).withName(SERVICE_DOMAIN_CLUSTER_NAME).create(desiredCluster);
             await().atMost(2, MINUTES).until(() -> client.resources(ServiceDomainCluster.class).inNamespace(SERVICE_DOMAIN_CLUSTER_NAMESPACE).withName(SERVICE_DOMAIN_CLUSTER_NAME).get() != null);
@@ -86,49 +85,36 @@ public class ServiceDomainControllerTest extends AbstractControllerTest{
 
         final String sdcNamespace = fetchedCluster.getMetadata().getNamespace();
         //update the kafka broker owner with the cluster uid
-        expectedKafka = getExpectedKafKa(fetchedCluster.getMetadata().getUid(), SERVICE_DOMAIN_CLUSTER_NAME, sdcNamespace);
+        expectedKafka = getExpectedKafKa(fetchedCluster);
         fetchedKafka = client.resources(Kafka.class).inNamespace(sdcNamespace).withName(SERVICE_DOMAIN_CLUSTER_NAME).get();
-        if(fetchedKafka != null) {
+        if (fetchedKafka != null) {
             client.resources(Kafka.class).inNamespace(sdcNamespace).replace(expectedKafka);
             await().atMost(2, MINUTES).until(() -> client.resources(Kafka.class).inNamespace(sdcNamespace).withName(SERVICE_DOMAIN_CLUSTER_NAME).get() != null);
         }
-
-        await().atMost(2, MINUTES).until(() -> client.rbac().roles().withName(SERVICE_DOMAIN_ROLE).get() != null);
-        Role role = client.rbac().roles().withName(SERVICE_DOMAIN_ROLE).get();
-        assertNotNull(role);
-
-        await().atMost(2, MINUTES).until(() -> client.rbac().roleBindings().withName(ROLE_BINDING).get() != null);
-        RoleBinding roleBinding = client.rbac().roleBindings().withName(ROLE_BINDING).get();
-        assertNotNull(roleBinding);
     }
 
     @AfterEach
-    public void afterEach(){
+    public void afterEach() {
         final NamespacedKubernetesClient client = mockServer.getClient();
 
-        ServiceAccount serviceAccount = client.serviceAccounts().inNamespace(SERVICE_DOMAIN_CLUSTER_NAMESPACE).withName(BINDING_SERVICE_SA).get();
-        if(serviceAccount != null){
-            client.resources(ServiceAccount.class).inNamespace(SERVICE_DOMAIN_CLUSTER_NAMESPACE).delete(serviceAccount);
-        }
-
         Deployment sdDeployment = client.apps().deployments().inNamespace(SERVICE_DOMAIN_CLUSTER_NAMESPACE).withName(SERVICE_DOMAIN_NAME).get();
-        if(sdDeployment != null){
+        if (sdDeployment != null) {
             client.resources(Deployment.class).inNamespace(SERVICE_DOMAIN_CLUSTER_NAMESPACE).delete(sdDeployment);
         }
 
         Service service = client.services().inNamespace(SERVICE_DOMAIN_CLUSTER_NAMESPACE).withName(SERVICE_DOMAIN_NAME).get();
-        if(service != null){
+        if (service != null) {
             client.resources(Service.class).inNamespace(SERVICE_DOMAIN_CLUSTER_NAMESPACE).delete(service);
         }
 
         KafkaTopic kafkaTopic = client.resources(KafkaTopic.class).inNamespace(SERVICE_DOMAIN_CLUSTER_NAMESPACE).withName(SERVICE_DOMAIN_NAME + "-topic").get();
-        if(kafkaTopic != null){
+        if (kafkaTopic != null) {
             client.resources(KafkaTopic.class).inNamespace(SERVICE_DOMAIN_CLUSTER_NAMESPACE).delete(kafkaTopic);
         }
 
         final String sdConfigMapName = "integration-" + SERVICE_DOMAIN_NAME + "-http";
         final ConfigMap configMap = client.configMaps().inNamespace(client.getNamespace()).withName(sdConfigMapName).get();
-        if(configMap != null){
+        if (configMap != null) {
             client.configMaps().inNamespace(client.getNamespace()).delete(configMap);
         }
 
@@ -141,12 +127,12 @@ public class ServiceDomainControllerTest extends AbstractControllerTest{
                 .build();
 
         final GenericKubernetesResource integration = client.genericKubernetesResources(resourceDefinitionContext).inNamespace(SERVICE_DOMAIN_CLUSTER_NAMESPACE).withName(integrationName).get();
-        if(integration != null){
+        if (integration != null) {
             client.genericKubernetesResources(resourceDefinitionContext).inNamespace(SERVICE_DOMAIN_CLUSTER_NAMESPACE).delete(integration);
         }
 
         final KubernetesResourceList<ServiceDomain> sdList = client.resources(ServiceDomain.class).inNamespace(SERVICE_DOMAIN_CLUSTER_NAMESPACE).list();
-        if(sdList != null && sdList.getItems() != null && !sdList.getItems().isEmpty()){
+        if (sdList != null && sdList.getItems() != null && !sdList.getItems().isEmpty()) {
             for (ServiceDomain sd : sdList.getItems()) {
                 client.resources(ServiceDomain.class).inNamespace(SERVICE_DOMAIN_CLUSTER_NAMESPACE).delete(sd);
                 await().atMost(2, MINUTES).until(() -> client.resources(ServiceDomain.class).inNamespace(SERVICE_DOMAIN_CLUSTER_NAMESPACE).withName(sd.getMetadata().getName()).get() == null);
@@ -154,49 +140,34 @@ public class ServiceDomainControllerTest extends AbstractControllerTest{
         }
 
         ServiceDomainCluster fetchedCluster = client.resources(ServiceDomainCluster.class).inNamespace(SERVICE_DOMAIN_CLUSTER_NAMESPACE).withName(SERVICE_DOMAIN_CLUSTER_NAME).get();
-        if(fetchedCluster != null){
+        if (fetchedCluster != null) {
             client.resources(ServiceDomainCluster.class).inNamespace(SERVICE_DOMAIN_CLUSTER_NAMESPACE).delete(fetchedCluster);
         }
 
         final Kafka kafka = client.resources(Kafka.class).inNamespace(SERVICE_DOMAIN_CLUSTER_NAMESPACE).withName(SERVICE_DOMAIN_CLUSTER_NAME).get();
-        if(kafka != null){
+        if (kafka != null) {
             client.resources(Kafka.class).inNamespace(SERVICE_DOMAIN_CLUSTER_NAMESPACE).delete(kafka);
         }
     }
 
     @Test
-    public void addServiceDomainTest(){
+    public void addServiceDomainTest() {
         ServiceDomain sd = createServiceDomain();
         final String sdNamespace = sd.getMetadata().getNamespace();
         final NamespacedKubernetesClient client = mockServer.getClient();
 
         sd = client.resources(ServiceDomain.class).inNamespace(sdNamespace).create(sd);
 
-        //Test service account data
-        await().atMost(2, MINUTES).until(() -> client.serviceAccounts().inNamespace(sdNamespace).withName(BINDING_SERVICE_SA).get() != null);
-        final ServiceAccount serviceAccount = client.serviceAccounts().inNamespace(sdNamespace).withName(BINDING_SERVICE_SA).get();
-        assertNotNull(serviceAccount);
-
-        List<OwnerReference> ownerReferences = serviceAccount.getMetadata().getOwnerReferences();
-        assertNotNull(ownerReferences);
-        assertFalse(ownerReferences.isEmpty());
-
-        OwnerReference ownerReference = ownerReferences.get(0);
-        assertNotNull(ownerReference);
-        assertEquals(sd.getMetadata().getName(), ownerReference.getName());
-        assertEquals(ServiceDomainController.SERVICE_DOMAIN_OWNER_REFERENCES_KIND, ownerReference.getKind());
-        assertEquals(ServiceDomainController.SERVICE_DOMAIN_OWNER_REFERENCES_API_VERSION, ownerReference.getApiVersion());
-
         //Test deployment data
         await().atMost(2, MINUTES).until(() -> client.apps().deployments().inNamespace(sdNamespace).withName(SERVICE_DOMAIN_NAME).get() != null);
         final Deployment deployment = client.apps().deployments().inNamespace(sdNamespace).withName(SERVICE_DOMAIN_NAME).get();
         assertNotNull(deployment);
 
-        ownerReferences = deployment.getMetadata().getOwnerReferences();
+        List<OwnerReference> ownerReferences = deployment.getMetadata().getOwnerReferences();
         assertNotNull(ownerReferences);
         assertFalse(ownerReferences.isEmpty());
 
-        ownerReference = ownerReferences.get(0);
+        OwnerReference ownerReference = ownerReferences.get(0);
         assertNotNull(ownerReference);
         assertEquals(sd.getMetadata().getName(), ownerReference.getName());
         assertEquals(ServiceDomainController.SERVICE_DOMAIN_OWNER_REFERENCES_KIND, ownerReference.getKind());
@@ -247,38 +218,23 @@ public class ServiceDomainControllerTest extends AbstractControllerTest{
     }
 
     @Test
-    public void updateServiceDomainNoExposeTest(){
+    public void updateServiceDomainNoExposeTest() {
         ServiceDomain sd = createServiceDomain();
         final String sdNamespace = sd.getMetadata().getNamespace();
         final NamespacedKubernetesClient client = mockServer.getClient();
 
         sd = client.resources(ServiceDomain.class).inNamespace(sdNamespace).create(sd);
 
-        //Test service account data
-        await().atMost(2, MINUTES).until(() -> client.serviceAccounts().inNamespace(sdNamespace).withName(BINDING_SERVICE_SA).get() != null);
-        final ServiceAccount serviceAccount = client.serviceAccounts().inNamespace(sdNamespace).withName(BINDING_SERVICE_SA).get();
-        assertNotNull(serviceAccount);
-
-        List<OwnerReference> ownerReferences = serviceAccount.getMetadata().getOwnerReferences();
-        assertNotNull(ownerReferences);
-        assertFalse(ownerReferences.isEmpty());
-
-        OwnerReference ownerReference = ownerReferences.get(0);
-        assertNotNull(ownerReference);
-        assertEquals(sd.getMetadata().getName(), ownerReference.getName());
-        assertEquals(ServiceDomainController.SERVICE_DOMAIN_OWNER_REFERENCES_KIND, ownerReference.getKind());
-        assertEquals(ServiceDomainController.SERVICE_DOMAIN_OWNER_REFERENCES_API_VERSION, ownerReference.getApiVersion());
-
         //Test deployment data
         await().atMost(2, MINUTES).until(() -> client.apps().deployments().inNamespace(sdNamespace).withName(SERVICE_DOMAIN_NAME).get() != null);
         final Deployment deployment = client.apps().deployments().inNamespace(sdNamespace).withName(SERVICE_DOMAIN_NAME).get();
         assertNotNull(deployment);
 
-        ownerReferences = deployment.getMetadata().getOwnerReferences();
+        List<OwnerReference> ownerReferences = deployment.getMetadata().getOwnerReferences();
         assertNotNull(ownerReferences);
         assertFalse(ownerReferences.isEmpty());
 
-        ownerReference = ownerReferences.get(0);
+        OwnerReference ownerReference = ownerReferences.get(0);
         assertNotNull(ownerReference);
         assertEquals(sd.getMetadata().getName(), ownerReference.getName());
         assertEquals(ServiceDomainController.SERVICE_DOMAIN_OWNER_REFERENCES_KIND, ownerReference.getKind());
@@ -336,7 +292,7 @@ public class ServiceDomainControllerTest extends AbstractControllerTest{
     }
 
     @Test
-    public void addServiceDomainWithNoClusterTest(){
+    public void addServiceDomainWithNoClusterTest() {
         final NamespacedKubernetesClient client = mockServer.getClient();
 
         client.resources(ServiceDomainCluster.class).inNamespace(SERVICE_DOMAIN_CLUSTER_NAMESPACE).withName(SERVICE_DOMAIN_CLUSTER_NAME).delete();
@@ -352,7 +308,7 @@ public class ServiceDomainControllerTest extends AbstractControllerTest{
     }
 
     @Test
-    public void addServiceDomainWithNoKafkaBrokerUrlTest(){
+    public void addServiceDomainWithNoKafkaBrokerUrlTest() {
         final NamespacedKubernetesClient client = mockServer.getClient();
 
         client.resources(ServiceDomainCluster.class).inNamespace(SERVICE_DOMAIN_CLUSTER_NAMESPACE).withName(SERVICE_DOMAIN_CLUSTER_NAME).delete();
@@ -379,38 +335,23 @@ public class ServiceDomainControllerTest extends AbstractControllerTest{
     }
 
     @Test
-    public void addServiceDomainWithoutExposeHttpTest(){
+    public void addServiceDomainWithoutExposeHttpTest() {
         ServiceDomain sd = createServiceDomain(SERVICE_DOMAIN_NAME, false);
         final String sdNamespace = sd.getMetadata().getNamespace();
         final NamespacedKubernetesClient client = mockServer.getClient();
 
         sd = client.resources(ServiceDomain.class).inNamespace(sdNamespace).create(sd);
 
-        //Test service account data
-        await().atMost(2, MINUTES).until(() -> client.serviceAccounts().inNamespace(sdNamespace).withName(BINDING_SERVICE_SA).get() != null);
-        final ServiceAccount serviceAccount = client.serviceAccounts().inNamespace(sdNamespace).withName(BINDING_SERVICE_SA).get();
-        assertNotNull(serviceAccount);
-
-        List<OwnerReference> ownerReferences = serviceAccount.getMetadata().getOwnerReferences();
-        assertNotNull(ownerReferences);
-        assertFalse(ownerReferences.isEmpty());
-
-        OwnerReference ownerReference = ownerReferences.get(0);
-        assertNotNull(ownerReference);
-        assertEquals(sd.getMetadata().getName(), ownerReference.getName());
-        assertEquals(ServiceDomainController.SERVICE_DOMAIN_OWNER_REFERENCES_KIND, ownerReference.getKind());
-        assertEquals(ServiceDomainController.SERVICE_DOMAIN_OWNER_REFERENCES_API_VERSION, ownerReference.getApiVersion());
-
         //Test deployment data
         await().atMost(2, MINUTES).until(() -> client.apps().deployments().inNamespace(sdNamespace).withName(SERVICE_DOMAIN_NAME).get() != null);
         final Deployment deployment = client.apps().deployments().inNamespace(sdNamespace).withName(SERVICE_DOMAIN_NAME).get();
         assertNotNull(deployment);
 
-        ownerReferences = deployment.getMetadata().getOwnerReferences();
+        List<OwnerReference> ownerReferences = deployment.getMetadata().getOwnerReferences();
         assertNotNull(ownerReferences);
         assertFalse(ownerReferences.isEmpty());
 
-        ownerReference = ownerReferences.get(0);
+        OwnerReference ownerReference = ownerReferences.get(0);
         assertNotNull(ownerReference);
         assertEquals(sd.getMetadata().getName(), ownerReference.getName());
         assertEquals(ServiceDomainController.SERVICE_DOMAIN_OWNER_REFERENCES_KIND, ownerReference.getKind());
@@ -450,16 +391,12 @@ public class ServiceDomainControllerTest extends AbstractControllerTest{
     }
 
     @Test
-    public void addMultipleServiceDomainTest(){
+    public void addMultipleServiceDomainTest() {
         ServiceDomain sd = createServiceDomain();
         final String sdNamespace = sd.getMetadata().getNamespace();
         final NamespacedKubernetesClient client = mockServer.getClient();
 
         client.resources(ServiceDomain.class).inNamespace(sdNamespace).create(sd);
-
-        await().atMost(2, MINUTES).until(() -> client.serviceAccounts().inNamespace(sdNamespace).withName(BINDING_SERVICE_SA).get() != null);
-        ServiceAccount serviceAccount = client.serviceAccounts().inNamespace(sdNamespace).withName(BINDING_SERVICE_SA).get();
-        assertNotNull(serviceAccount);
 
         await().atMost(2, MINUTES).until(() -> client.apps().deployments().inNamespace(sdNamespace).withName(SERVICE_DOMAIN_NAME).get() != null);
         Deployment sdDeployment = client.apps().deployments().inNamespace(sdNamespace).withName(SERVICE_DOMAIN_NAME).get();
@@ -476,10 +413,6 @@ public class ServiceDomainControllerTest extends AbstractControllerTest{
         sd = createServiceDomain(SERVICE_DOMAIN_NAME + 2);
 
         client.resources(ServiceDomain.class).inNamespace(sdNamespace).create(sd);
-
-        await().atMost(2, MINUTES).until(() -> client.serviceAccounts().inNamespace(sdNamespace).withName(BINDING_SERVICE_SA).get() != null);
-        serviceAccount = client.serviceAccounts().inNamespace(sdNamespace).withName(BINDING_SERVICE_SA).get();
-        assertNotNull(serviceAccount);
 
         await().atMost(2, MINUTES).until(() -> client.apps().deployments().inNamespace(sdNamespace).withName(SERVICE_DOMAIN_NAME + 2).get() != null);
         sdDeployment = client.apps().deployments().inNamespace(sdNamespace).withName(SERVICE_DOMAIN_NAME + 2).get();


### PR DESCRIPTION
Signed-off-by: ruromero <rromerom@redhat.com>

* Removed unused ServiceAccounts and Roles
* Disabled CRD validation and related roles
* Added the possibility to configure Kafka replicas and storage type
* Added SDC and SD examples
* Use of `createOrUpdate`