### PR TITLE
Upgrade Kafka and Fix status reconciliation

### DIFF
--- a/mercury-api/src/main/java/com/redhat/mercury/operator/model/AbstractResourceStatus.java
+++ b/mercury-api/src/main/java/com/redhat/mercury/operator/model/AbstractResourceStatus.java
@@ -29,6 +29,9 @@ public abstract class AbstractResourceStatus {
 
     public static final String REASON_SUCCESS = "Success";
     public static final String REASON_FAILED = "Failed";
+    public static final String REASON_WAITING = "Waiting";
+
+    public static final String MESSAGE_WAITING = "Waiting for other resources to become Ready";
 
     public static final String STATUS_FALSE = "False";
     public static final String STATUS_TRUE = "True";

--- a/mercury-framework/examples/deploy/customer-credit-rating-service-domain.yaml
+++ b/mercury-framework/examples/deploy/customer-credit-rating-service-domain.yaml
@@ -1,7 +1,7 @@
 apiVersion: mercury.redhat.io/v1alpha1
 kind: ServiceDomain
 metadata:
-  name: customer-credit-rating
+  name: example-customer-credit-rating
   labels:
     service-domain: customer-credit-rating
 spec:

--- a/mercury-framework/examples/deploy/customer-offer-service-domain.yaml
+++ b/mercury-framework/examples/deploy/customer-offer-service-domain.yaml
@@ -1,7 +1,7 @@
 apiVersion: mercury.redhat.io/v1alpha1
 kind: ServiceDomain
 metadata:
-  name: customer-offer
+  name: example-customer-offer
   labels:
     service-domain: customer-offer
 spec:

--- a/mercury-framework/examples/deploy/party-routing-profile-service-domain.yaml
+++ b/mercury-framework/examples/deploy/party-routing-profile-service-domain.yaml
@@ -1,7 +1,7 @@
 apiVersion: mercury.redhat.io/v1alpha1
 kind: ServiceDomain
 metadata:
-  name: party-routing-profile
+  name: example-party-routing-profile
   labels:
     service-domain: party-routing-profile
 spec:

--- a/mercury-operator/src/test/java/com/redhat/mercury/operator/controller/AbstractControllerTest.java
+++ b/mercury-operator/src/test/java/com/redhat/mercury/operator/controller/AbstractControllerTest.java
@@ -46,7 +46,7 @@ public abstract class AbstractControllerTest {
         final Kafka kafka = serviceDomainClusterController.createKafkaObj(sdc);
 
         final KafkaStatus status = new KafkaStatusBuilder().withListeners(new ListenerStatusBuilder()
-                        .withType(KAFKA_LISTENER_TYPE_PLAIN)
+                        .withName(KAFKA_LISTENER_TYPE_PLAIN)
                         .withAddresses(List.of(new ListenerAddressBuilder()
                                 .withHost("www.test.com")
                                 .build()))

--- a/mercury-operator/src/test/java/com/redhat/mercury/operator/controller/ServiceDomainClusterControllerTest.java
+++ b/mercury-operator/src/test/java/com/redhat/mercury/operator/controller/ServiceDomainClusterControllerTest.java
@@ -89,7 +89,7 @@ public class ServiceDomainClusterControllerTest extends AbstractControllerTest {
         assertThat(condition.getMessage()).isEqualTo("Unsupported kafka storage type: invalid type supported values are 'ephemeral' and 'persistent-volume-claim'");
         assertThat(condition.getLastTransitionTime()).isNotNull();
 
-        assertThatIsNotReady(update);
+        assertThatIsWaiting(update);
 
         Kafka kafka = mockServer.getClient().resources(Kafka.class).inNamespace(sdc.getMetadata().getNamespace()).withName(sdc.getMetadata().getName()).get();
         assertThat(kafka).isNull();
@@ -115,7 +115,7 @@ public class ServiceDomainClusterControllerTest extends AbstractControllerTest {
         assertThat(condition.getMessage()).contains(exceptionMessage);
         assertThat(condition.getLastTransitionTime()).isNotNull();
 
-        assertThatIsNotReady(update);
+        assertThatIsWaiting(update);
 
         Kafka kafka = mockServer.getClient().resources(Kafka.class).inNamespace(sdc.getMetadata().getNamespace()).withName(sdc.getMetadata().getName()).get();
         assertThat(kafka).isNull();
@@ -135,7 +135,7 @@ public class ServiceDomainClusterControllerTest extends AbstractControllerTest {
         assertThat(condition.getMessage()).isEqualTo(MESSAGE_KAFKA_BROKER_NOT_READY);
         assertThat(condition.getLastTransitionTime()).isNotNull();
 
-        assertThatIsNotReady(update);
+        assertThatIsWaiting(update);
 
         Kafka kafka = mockServer.getClient().resources(Kafka.class).inNamespace(sdc.getMetadata().getNamespace()).withName(sdc.getMetadata().getName()).get();
         assertEphemeralKafka(kafka);
@@ -164,7 +164,7 @@ public class ServiceDomainClusterControllerTest extends AbstractControllerTest {
         assertThat(condition.getMessage()).isEqualTo(MESSAGE_KAFKA_BROKER_NOT_READY);
         assertThat(condition.getLastTransitionTime()).isNotNull();
 
-        assertThatIsNotReady(update);
+        assertThatIsWaiting(update);
 
         Kafka kafka = mockServer.getClient().resources(Kafka.class).inNamespace(sdc.getMetadata().getNamespace()).withName(sdc.getMetadata().getName()).get();
         assertEphemeralKafka(kafka);
@@ -186,14 +186,10 @@ public class ServiceDomainClusterControllerTest extends AbstractControllerTest {
         assertThat(condition.getMessage()).isEqualTo(MESSAGE_KAFKA_BROKER_NOT_READY);
         assertThat(condition.getLastTransitionTime()).isNotNull();
 
-        assertThatIsNotReady(update);
+        assertThatIsWaiting(update);
 
         Kafka kafka = mockServer.getClient().resources(Kafka.class).inNamespace(sdc.getMetadata().getNamespace()).withName(sdc.getMetadata().getName()).get();
         assertEphemeralKafka(kafka);
-
-        // Update Kafka
-        update = serviceDomainClusterController.reconcile(sdc, null);
-        assertThat(update.isNoUpdate()).isTrue();
     }
 
     @Test
@@ -212,7 +208,7 @@ public class ServiceDomainClusterControllerTest extends AbstractControllerTest {
         assertThat(condition.getMessage()).isEqualTo(MESSAGE_KAFKA_BROKER_NOT_READY);
         assertThat(condition.getLastTransitionTime()).isNotNull();
 
-        assertThatIsNotReady(update);
+        assertThatIsWaiting(update);
 
         Kafka kafka = mockServer.getClient().resources(Kafka.class).inNamespace(sdc.getMetadata().getNamespace()).withName(sdc.getMetadata().getName()).get();
         assertEphemeralKafka(kafka);
@@ -241,6 +237,7 @@ public class ServiceDomainClusterControllerTest extends AbstractControllerTest {
         assertThat(condition.getLastTransitionTime()).isNotBlank();
         assertThat(condition.getReason()).isNull();
         assertThat(condition.getMessage()).isNull();
+        assertThatIsReady(update);
     }
 
     @Test
@@ -271,7 +268,7 @@ public class ServiceDomainClusterControllerTest extends AbstractControllerTest {
         assertThat(condition.getMessage()).isEqualTo(MESSAGE_KAFKA_BROKER_NOT_READY);
         assertThat(condition.getLastTransitionTime()).isNotNull();
 
-        assertThatIsNotReady(update);
+        assertThatIsWaiting(update);
 
         Kafka kafka = mockServer.getClient().resources(Kafka.class).inNamespace(sdc.getMetadata().getNamespace()).withName(sdc.getMetadata().getName()).get();
         assertThat(kafka).isNotNull();

--- a/mercury-operator/src/test/java/com/redhat/mercury/operator/controller/ServiceDomainClusterControllerTest.java
+++ b/mercury-operator/src/test/java/com/redhat/mercury/operator/controller/ServiceDomainClusterControllerTest.java
@@ -219,7 +219,7 @@ public class ServiceDomainClusterControllerTest extends AbstractControllerTest {
 
         // Update Kafka
         kafka.setStatus(new KafkaStatusBuilder().withListeners(new ListenerStatusBuilder()
-                        .withType(KAFKA_LISTENER_TYPE_PLAIN)
+                        .withName(KAFKA_LISTENER_TYPE_PLAIN)
                         .withAddresses(new ListenerAddressBuilder()
                                 .withHost("my-kafka.example.com")
                                 .withPort(9092)

--- a/pom.xml
+++ b/pom.xml
@@ -24,7 +24,7 @@
         <lombok.version>1.18.16</lombok.version>
         <builder-annotations.version>0.50.3</builder-annotations.version>
         <operator-sdk.version>3.0.3</operator-sdk.version>
-        <strimzi-api.version>0.27.1</strimzi-api.version>
+        <strimzi-api.version>0.28.0</strimzi-api.version>
         <archetype.version>3.2.0</archetype.version>
         <!-- Image build properties -->
         <quarkus.native.container-build>true</quarkus.native.container-build>


### PR DESCRIPTION
Update status control

* There was a problem updating the resource states and the Service
Domains wouldn't become Ready
* Fixed the case where the SDC is not Ready and the SD is created
* Upgraded to Kafka 0.28.0

Signed-off-by: ruromero <rromerom@redhat.com>