### PR TITLE
Add printer columns for better visibility

### DIFF
--- a/deploy/crd/servicedomaininfras.mercury.redhat.io-v1.yml
+++ b/deploy/crd/servicedomaininfras.mercury.redhat.io-v1.yml
@@ -63,3 +63,13 @@ spec:
     storage: true
     subresources:
       status: {}
+    additionalPrinterColumns:
+      - description: Resource is Ready
+        jsonPath: .status.conditions[?(@.type=='Ready')].status
+        name: Ready
+        type: string
+      - description: Kafka cluster status is ready
+        jsonPath: .status.conditions[?(@.type=='KafkaBrokerReady')].status
+        name: Kafka
+        type: string
+

--- a/deploy/crd/servicedomains.mercury.redhat.io-v1.yml
+++ b/deploy/crd/servicedomains.mercury.redhat.io-v1.yml
@@ -69,3 +69,24 @@ spec:
     storage: true
     subresources:
       status: {}
+    additionalPrinterColumns:
+      - description: Resource is Ready
+        jsonPath: .status.conditions[?(@.type=='Ready')].status
+        name: Ready
+        type: string
+      - description: Service Domain Infra Name
+        jsonPath: .spec.serviceDomainInfra
+        name: Infra
+        type: string
+      - description: Service Domain Infra status is ready
+        jsonPath: .status.conditions[?(@.type=='ServiceDomainInfraReady')].status
+        name: InfraReady
+        type: string
+      - description: Integration status is ready
+        jsonPath: .status.conditions[?(@.type=='IntegrationReady')].status
+        name: Integration
+        type: string
+      - description: Kafka topic status is ready
+        jsonPath: .status.conditions[?(@.type=='KafkaTopicReady')].status
+        name: Topic
+        type: string

--- a/deploy/olm-catalog/1.0.2/bundle/manifests/servicedomaininfras.mercury.redhat.io-v1.yml
+++ b/deploy/olm-catalog/1.0.2/bundle/manifests/servicedomaininfras.mercury.redhat.io-v1.yml
@@ -63,3 +63,13 @@ spec:
     storage: true
     subresources:
       status: {}
+    additionalPrinterColumns:
+      - description: Resource is Ready
+        jsonPath: .status.conditions[?(@.type=='Ready')].status
+        name: Ready
+        type: string
+      - description: Kafka cluster status is ready
+        jsonPath: .status.conditions[?(@.type=='KafkaBrokerReady')].status
+        name: Kafka
+        type: string
+

--- a/deploy/olm-catalog/1.0.2/bundle/manifests/servicedomains.mercury.redhat.io-v1.yml
+++ b/deploy/olm-catalog/1.0.2/bundle/manifests/servicedomains.mercury.redhat.io-v1.yml
@@ -69,3 +69,24 @@ spec:
     storage: true
     subresources:
       status: {}
+    additionalPrinterColumns:
+      - description: Resource is Ready
+        jsonPath: .status.conditions[?(@.type=='Ready')].status
+        name: Ready
+        type: string
+      - description: Service Domain Infra Name
+        jsonPath: .spec.serviceDomainInfra
+        name: Infra
+        type: string
+      - description: Service Domain Infra status is ready
+        jsonPath: .status.conditions[?(@.type=='ServiceDomainInfraReady')].status
+        name: InfraReady
+        type: string
+      - description: Integration status is ready
+        jsonPath: .status.conditions[?(@.type=='IntegrationReady')].status
+        name: Integration
+        type: string
+      - description: Kafka topic status is ready
+        jsonPath: .status.conditions[?(@.type=='KafkaTopicReady')].status
+        name: Topic
+        type: string


### PR DESCRIPTION
Add printer columns for ServiceDomain and Infra for better visibility in the CLI

## ServiceDomains

```
NAME                             READY   INFRA                  INFRAREADY   INTEGRATION   TOPIC
example-customer-credit-rating   True    service-domain-infra   True         True          True
example-customer-offer           False   service-domain-infra   True         False         True
example-party-routing-profile    False   service-domain-infra   True         False         True
```

## ServiceDomainInfras

```
NAME                   READY   KAFKAREADY
service-domain-infra   True    True
```

Signed-off-by: ruromero <rromerom@redhat.com>